### PR TITLE
Support Cadence Xcelium and UVM 1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,6 @@ nccomp:
 
 ncrun:
 	$(NC2) \
-	-R -nclibdirname INCA_libs \
+	-R \
 	-input ida_probe.tcl \
 	$(EXTRA_RUN_ARGS)

--- a/Makefile.master.nc
+++ b/Makefile.master.nc
@@ -23,6 +23,7 @@ NC =    irun +sv +nctimescale+1ns/10ps \
 # NC2 will use the version of UVM that ships with Cadence
 # The Cadence UVM version is needed for Indago to run
 NC2 =   irun +sv +nctimescale+1ns/10ps \
+        -nclibdirname INCA_libs \
         +define+UVM_NO_DEPRECATED \
         +define+UVM_1p1d \
         +UVM_VERBOSITY=$(UVM_VERBOSITY)  \

--- a/Makefile.master.nc
+++ b/Makefile.master.nc
@@ -13,6 +13,13 @@ TEST = /usr/bin/test
 N_ERRS = 0
 N_FATALS = 0
 
+ifeq ($(UVM_VERSION),1p2)
+CDNS_UVM_DIR=CDNS-1.2
+else
+CDNS_UVM_DIR=CDNS-1.1d
+endif
+
+
 NC =    irun +sv +nctimescale+1ns/10ps \
         +define+UVM_NO_DEPRECATED \
         +define+UVM_$(UVM_VERSION) \
@@ -25,10 +32,10 @@ NC =    irun +sv +nctimescale+1ns/10ps \
 NC2 =   irun +sv +nctimescale+1ns/10ps \
         -nclibdirname INCA_libs \
         +define+UVM_NO_DEPRECATED \
-        +define+UVM_1p1d \
+        +define+UVM_$(UVM_VERSION) \
         +UVM_VERBOSITY=$(UVM_VERBOSITY)  \
         +incdir+./ \
-	-uvm
+	-uvmhome $(CDNS_UVM_DIR)
 
 ncclean:
 	rm -rf *~ *.log INCA_libs/ ida.db/ .ida.db_safe*


### PR DESCRIPTION
The compile flow for Cadence Incisive assumes the build directory will be named INCA_libs, which is the default for Incisive but not for the newer Xcelium. The first commit in this change makes this directory name explicit on both the compile and run steps, so we don't rely on the default anymore.

The second commit enables UVM 1.2 to work in the Cadence flow. Previously it was hardwired for 1.1d.