### PR TITLE
Fix compile error from Mentor Questa

### DIFF
--- a/custom_report_server.sv
+++ b/custom_report_server.sv
@@ -178,7 +178,7 @@ class custom_report_server extends
          uvm_report_handler l_report_handler;
          string message  = "";
          string filename = "";
-         string line     = "";
+         int    line     = 0;
          string id       = "";
    `else
          virtual function string compose_message


### PR DESCRIPTION
** Error (suppressible): custom_report_server.sv(406): (vlog-7070) Assigning a packed type 'int' to a string requires a cast.

Also tested on Cadence Xcelium. Not tested on VCS.